### PR TITLE
Embed essential NuGets

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to use nuget packages it is recommended to use the [Flatpak .NET Gen
 ```json
 "build-commands": [
     "install.sh",
-    "dotnet publish -c Release --source ./nuget-sources YourProject.csproj",
+    "dotnet publish -c Release --source ./nuget-sources --source /usr/lib/sdk/dotnet9/nuget/packages YourProject.csproj",
     "cp -r --remove-destination /run/build/YourProject/bin/Release/net9.0/publish/ /app/bin/"
 ],
 "sources": [
@@ -46,62 +46,7 @@ If you want to use nuget packages it is recommended to use the [Flatpak .NET Gen
 ### Publishing self contained app and trimmed binaries
 .NET 9 gives option to include runtime in published application and trim their binaries. This allows you to significantly reduce the size of the package and get rid of `/usr/lib/sdk/dotnet9/bin/install.sh`. 
 
-First you need to have following lines in `sources.json`. These packages are needed to build a project for specific runtime. 
-
-```json
-{
-    "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/9.0.11/microsoft.aspnetcore.app.runtime.linux-arm64.9.0.11.nupkg",
-    "sha512": "cfa9709633e91184bdd061951bf480e66da86175384e3a35ccc9ebbc768f207785807bc48628fd4101ecf6336a9495fbc9cb02aea3c0b9543c02e73fb96fb4f8",
-    "dest": "nuget-sources",
-    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-arm64.9.0.11.nupkg",
-    "x-checker-data": {
-        "type": "html",
-        "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version",
-        "version-pattern": "^([\\d\\.a-z-]+)$",
-        "url-template": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/$version/microsoft.aspnetcore.app.runtime.linux-arm64.$version.nupkg"
-    }
-},
-{
-    "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.11/microsoft.aspnetcore.app.runtime.linux-x64.9.0.11.nupkg",
-    "sha512": "5373c5f77dc775544b72d4994101cac0618ca885518a44b928cd888086f9287f73a17af3642a6b017242beb6500e83ad68a3a7f9ebb217e832ebd0af781fa03b",
-    "dest": "nuget-sources",
-    "dest-filename": "microsoft.aspnetcore.app.runtime.linux-x64.9.0.11.nupkg",
-    "x-checker-data": {
-        "type": "html",
-        "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version",
-        "version-pattern": "^([\\d\\.a-z-]+)$",
-        "url-template": "https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/$version/microsoft.aspnetcore.app.runtime.linux-x64.$version.nupkg"
-    }
-},
-{
-    "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/9.0.11/microsoft.netcore.app.runtime.linux-arm64.9.0.11.nupkg",
-    "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.runtime.linux-arm64.9.0.11.nupkg",
-    "x-checker-data": {
-        "type": "html",
-        "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version",
-        "version-pattern": "^([\\d\\.a-z-]+)$",
-        "url-template": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/$version/microsoft.netcore.app.runtime.linux-arm64.$version.nupkg"
-    }
-},
-{
-    "type": "file",
-    "url": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.11/microsoft.netcore.app.runtime.linux-x64.9.0.11.nupkg",
-    "dest": "nuget-sources",
-    "dest-filename": "microsoft.netcore.app.runtime.linux-x64.9.0.11.nupkg",
-    "x-checker-data": {
-        "type": "html",
-        "url": "https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version",
-        "version-pattern": "^([\\d\\.a-z-]+)$",
-        "url-template": "https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/$version/microsoft.netcore.app.runtime.linux-x64.$version.nupkg"
-    }
-},
-```
-
-Then add build options:
+Slightly modify the `build-commands` and add the `build-options` as follows:
 
 ```json
 "build-options": {
@@ -120,7 +65,9 @@ Then add build options:
 },
 "build-commands": [
     "mkdir -p /app/bin",
-    "dotnet publish -c Release --source ./nuget-sources YourProject.csproj --runtime $RUNTIME --self-contained true",
+    "dotnet publish -c Release --source ./nuget-sources --source /usr/lib/sdk/dotnet9/nuget/packages YourProject.csproj --runtime $RUNTIME --self-contained true",
     "cp -r --remove-destination /run/build/YourProject/bin/Release/net9.0/$RUNTIME/publish/* /app/bin/",
 ],
 ```
+
+Note that your nuget packages directory is listed before the one provided with the SDK, the build may fail if ordered differently.

--- a/org.freedesktop.Sdk.Extension.dotnet9.yaml
+++ b/org.freedesktop.Sdk.Extension.dotnet9.yaml
@@ -31,6 +31,74 @@ modules:
           url: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/9.0/latest.version
           version-pattern: ^([\d\.a-z-]+)$
           url-template: https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$version/dotnet-sdk-$version-linux-arm64.tar.gz
+  - name: nuget-sources
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /usr/lib/sdk/dotnet9/nuget/packages
+      - cp * /usr/lib/sdk/dotnet9/nuget/packages
+    sources:
+      - type: file
+        only-arches: [x86_64]
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/9.0.0/microsoft.aspnetcore.app.runtime.linux-x64.9.0.0.nupkg
+        sha512: 6a1d62af51047864ac8630242a9f257dd978e163985c566673276f3919d022cdc878a0a4c2141364d92064ec22793d4db460744cb6dcd21d45495eac511967b9
+        x-checker-data:
+          type: html
+          url: https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version
+          version-pattern: '^([\d\.a-z-]+)$'
+          url-template: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-x64/$version/microsoft.aspnetcore.app.runtime.linux-x64.$version.nupkg
+      - type: file
+        only-arches: [x86_64]
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/9.0.0/microsoft.netcore.app.runtime.linux-x64.9.0.0.nupkg
+        sha512: b53da3f97f2c6899fd27ede233a328270bf99040215b2bb03de6598a9ab6eba603225c04696d850e3a160892552c2def08389d1e59d34fa20a52ffcb30a2a958
+        x-checker-data:
+          type: html
+          url: https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version
+          version-pattern: '^([\d\.a-z-]+)$'
+          url-template: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-x64/$version/microsoft.netcore.app.runtime.linux-x64.$version.nupkg
+      - type: file
+        only-arches: [x86_64]
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.crossgen2.linux-x64/9.0.0/microsoft.netcore.app.crossgen2.linux-x64.9.0.0.nupkg
+        sha512: b67071548bcea3a0e34558b006325cca58e9b0c667338e98d6f06a33c01b30cd5f3b405c28f6c94bcf069a7437ab4acd5a68ba1b6558ed460797ffbda6170608
+        x-checker-data:
+          type: html
+          url: https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version
+          version-pattern: '^([\d\.a-z-]+)$'
+          url-template: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.crossgen2.linux-x64/$version/microsoft.netcore.app.crossgen2.linux-x64.$version.nupkg
+      - type: file
+        only-arches: [aarch64]
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/9.0.0/microsoft.aspnetcore.app.runtime.linux-arm64.9.0.0.nupkg
+        sha512: 0f241403eef87387e31a0a86a539d75e44f9af4dc64a775e7a6dc9ec5d8ef96b0783b9e7f3b2878b62d1f72f112565c70fd71e48e54c06f4cbba533e56f46e3a
+        x-checker-data:
+          type: html
+          url: https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version
+          version-pattern: '^([\d\.a-z-]+)$'
+          url-template: https://api.nuget.org/v3-flatcontainer/microsoft.aspnetcore.app.runtime.linux-arm64/$version/microsoft.aspnetcore.app.runtime.linux-arm64.$version.nupkg
+      - type: file
+        only-arches: [aarch64]
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/9.0.0/microsoft.netcore.app.runtime.linux-arm64.9.0.0.nupkg
+        sha512: d2ffd83fed2192bef2cefcc62a13734bdff00249d0b47eae1fd934e0d7c8a798a70a3abd2f15ac2fe4b860220d0f0557d6855e512fff015bf64f8b03ba12338e
+        x-checker-data:
+          type: html
+          url: https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version
+          version-pattern: '^([\d\.a-z-]+)$'
+          url-template: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.runtime.linux-arm64/$version/microsoft.netcore.app.runtime.linux-arm64.$version.nupkg
+      - type: file
+        only-arches: [aarch64]
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.crossgen2.linux-arm64/9.0.0/microsoft.netcore.app.crossgen2.linux-arm64.9.0.0.nupkg
+        sha512: 0e7fd5f250d6deadc2fd4d777e4027d7024b360c19e9768c71bd2f397651396df601ed66124f6314e9e944d6f30a914a4141895fa4a0f3f89fb7996d5f7ff875
+        x-checker-data:
+          type: html
+          url: https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version
+          version-pattern: '^([\d\.a-z-]+)$'
+          url-template: https://api.nuget.org/v3-flatcontainer/microsoft.netcore.app.crossgen2.linux-arm64/$version/microsoft.netcore.app.crossgen2.linux-arm64.$version.nupkg
+      - type: file
+        url: https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/9.0.0/microsoft.net.illink.tasks.9.0.0.nupkg
+        sha512: c60d7deae05f9d498995ce5a8b37d38b9f3c332aee23d1e5bdaaa3de631bc7527d19fa45fadde075647ab8a6c7d25556f68c7327b1605fb356644663df78f46a
+        x-checker-data:
+          type: html
+          url: https://dotnetcli.blob.core.windows.net/dotnet/aspnetcore/Runtime/9.0/latest.version
+          version-pattern: '^([\d\.a-z-]+)$'
+          url-template: https://api.nuget.org/v3-flatcontainer/microsoft.net.illink.tasks/$version/microsoft.net.illink.tasks.$version.nupkg
   - name: scripts
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
This PR do the same thing as flathub/org.freedesktop.Sdk.Extension.dotnet8#27 and flathub/org.freedesktop.Sdk.Extension.dotnet8#28, that is, embed the following NuGets in the .NET 9 SDK:

- microsoft.aspnetcore.app.runtime.{x64,arm64}
- microsoft.netcore.app.runtime.{x64,arm64}
- microsoft.netcore.app.crossgen2.{x64,arm64}
- microsoft.net.illink.tasks

It also updates the publish instructions in the README.
